### PR TITLE
[WEEK 6] JPA 활용 미션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// queryDSL - 최신 방식으로 설정
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
@@ -43,7 +42,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-// Querydsl 설정부 - 최신 방식
 def querydslDir = "$buildDir/generated/querydsl"
 
 sourceSets {
@@ -54,7 +52,6 @@ tasks.withType(JavaCompile) {
 	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
 }
 
-// clean 태스크 실행 시 생성된 QClass 삭제
 clean {
 	delete file(querydslDir)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,37 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// queryDSL - 최신 방식으로 설정
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
+	implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.9'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+// Querydsl 설정부 - 최신 방식
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+tasks.withType(JavaCompile) {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+// clean 태스크 실행 시 생성된 QClass 삭제
+clean {
+	delete file(querydslDir)
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/_th/spring/Application.java
+++ b/src/main/java/umc/_th/spring/Application.java
@@ -43,7 +43,7 @@ public class Application {
 			Long memberId = 1L;
 			MissionStatus missionStatus = MissionStatus.CHALLENGING;
 
-			missionService.findAllMissionsByMemberIdAndStatus(memberId, missionStatus)
+			missionService.findAllMissionsByMemberIdAndStatus(memberId, missionStatus, PageRequest.of(1, 10))
 					.forEach(System.out::println);
 
 			MemberQueryService memberService = context.getBean(MemberQueryService.class);

--- a/src/main/java/umc/_th/spring/Application.java
+++ b/src/main/java/umc/_th/spring/Application.java
@@ -5,6 +5,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import umc._th.spring.domain.enums.MissionStatus;
 import umc._th.spring.service.MemberService.MemberQueryService;
@@ -45,6 +46,9 @@ public class Application {
 
 			MemberQueryService memberService = context.getBean(MemberQueryService.class);
 			memberService.findById(memberId).ifPresent(System.out::println);
+
+			missionService.findAllMissionsByRegion(1L, 1L, PageRequest.of(1, 10))
+					.forEach(System.out::println);
 		};
 	}
 

--- a/src/main/java/umc/_th/spring/Application.java
+++ b/src/main/java/umc/_th/spring/Application.java
@@ -7,9 +7,11 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import umc._th.spring.domain.Review;
 import umc._th.spring.domain.enums.MissionStatus;
 import umc._th.spring.service.MemberService.MemberQueryService;
 import umc._th.spring.service.MissionService.MissionQueryService;
+import umc._th.spring.service.ReviewService.ReviewCommandService;
 import umc._th.spring.service.StoreService.StoreQueryService;
 
 @SpringBootApplication
@@ -49,6 +51,10 @@ public class Application {
 
 			missionService.findAllMissionsByRegion(1L, 1L, PageRequest.of(1, 10))
 					.forEach(System.out::println);
+
+			ReviewCommandService reviewService = context.getBean(ReviewCommandService.class);
+			Review writtenReview = reviewService.createReview(memberId, 1L, "리뷰 작성 확인", 5F);
+			System.out.println(writtenReview);
 		};
 	}
 

--- a/src/main/java/umc/_th/spring/Application.java
+++ b/src/main/java/umc/_th/spring/Application.java
@@ -6,6 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import umc._th.spring.domain.enums.MissionStatus;
+import umc._th.spring.service.MissionService.MissionQueryService;
 import umc._th.spring.service.StoreService.StoreQueryService;
 
 @SpringBootApplication
@@ -19,6 +21,7 @@ public class Application {
 	@Bean
 	public CommandLineRunner run(ApplicationContext context) {
 		return args -> {
+			// 상점 찾는 쿼리
 			StoreQueryService storeService = context.getBean(StoreQueryService.class);
 
 			String name = "요아정";
@@ -29,6 +32,14 @@ public class Application {
 			System.out.println("Score: " + score);
 
 			storeService.findStoreByNameAndScore(name, score)
+					.forEach(System.out::println);
+
+			MissionQueryService missionService = context.getBean(MissionQueryService.class);
+
+			Long memberId = 1L;
+			MissionStatus missionStatus = MissionStatus.CHALLENGING;
+
+			missionService.findMissionByMemberIdAndStatus(memberId, missionStatus)
 					.forEach(System.out::println);
 		};
 	}

--- a/src/main/java/umc/_th/spring/Application.java
+++ b/src/main/java/umc/_th/spring/Application.java
@@ -41,7 +41,7 @@ public class Application {
 			Long memberId = 1L;
 			MissionStatus missionStatus = MissionStatus.CHALLENGING;
 
-			missionService.findMissionByMemberIdAndStatus(memberId, missionStatus)
+			missionService.findAllMissionsByMemberIdAndStatus(memberId, missionStatus)
 					.forEach(System.out::println);
 
 			MemberQueryService memberService = context.getBean(MemberQueryService.class);

--- a/src/main/java/umc/_th/spring/Application.java
+++ b/src/main/java/umc/_th/spring/Application.java
@@ -7,6 +7,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import umc._th.spring.domain.enums.MissionStatus;
+import umc._th.spring.service.MemberService.MemberQueryService;
 import umc._th.spring.service.MissionService.MissionQueryService;
 import umc._th.spring.service.StoreService.StoreQueryService;
 
@@ -41,6 +42,9 @@ public class Application {
 
 			missionService.findMissionByMemberIdAndStatus(memberId, missionStatus)
 					.forEach(System.out::println);
+
+			MemberQueryService memberService = context.getBean(MemberQueryService.class);
+			memberService.findById(memberId).ifPresent(System.out::println);
 		};
 	}
 

--- a/src/main/java/umc/_th/spring/Application.java
+++ b/src/main/java/umc/_th/spring/Application.java
@@ -1,8 +1,12 @@
 package umc._th.spring;
 
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import umc._th.spring.service.StoreService.StoreQueryService;
 
 @SpringBootApplication
 @EnableJpaAuditing
@@ -10,6 +14,23 @@ public class Application {
 
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
+	}
+
+	@Bean
+	public CommandLineRunner run(ApplicationContext context) {
+		return args -> {
+			StoreQueryService storeService = context.getBean(StoreQueryService.class);
+
+			String name = "요아정";
+			Float score = 4.0f;
+
+			System.out.println("Executing findStoresByNameAndScore with parameters:");
+			System.out.println("Name: " + name);
+			System.out.println("Score: " + score);
+
+			storeService.findStoreByNameAndScore(name, score)
+					.forEach(System.out::println);
+		};
 	}
 
 }

--- a/src/main/java/umc/_th/spring/Application.java
+++ b/src/main/java/umc/_th/spring/Application.java
@@ -2,8 +2,10 @@ package umc._th.spring;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/_th/spring/config/QueryDSLConfig.java
+++ b/src/main/java/umc/_th/spring/config/QueryDSLConfig.java
@@ -1,0 +1,18 @@
+package umc._th.spring.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/umc/_th/spring/domain/FoodType.java
+++ b/src/main/java/umc/_th/spring/domain/FoodType.java
@@ -1,0 +1,20 @@
+package umc._th.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class FoodType extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String name;
+}

--- a/src/main/java/umc/_th/spring/domain/Inquiry.java
+++ b/src/main/java/umc/_th/spring/domain/Inquiry.java
@@ -1,0 +1,30 @@
+package umc._th.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Inquiry extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(nullable = false, length = 40)
+    private String content;
+
+    @Column(length = 50)
+    private String image;
+
+    @Column(length = 40)
+    private String answer;
+}

--- a/src/main/java/umc/_th/spring/domain/Member.java
+++ b/src/main/java/umc/_th/spring/domain/Member.java
@@ -1,0 +1,62 @@
+package umc._th.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.common.BaseEntity;
+import umc._th.spring.domain.enums.Gender;
+import umc._th.spring.domain.enums.MemberStatus;
+import umc._th.spring.domain.enums.SocialType;
+import umc._th.spring.domain.mapping.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String address;
+
+    private String specAddress;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
+    private LocalDate inactiveDate;
+
+    private String email;
+
+    private Integer point;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberPrefer> memberPreferList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Review> reviewList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberMission> memberMissionList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberNotification> memberNotificationList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberNotificationType> memberNotificationTypeList = new ArrayList<>();
+}

--- a/src/main/java/umc/_th/spring/domain/Member.java
+++ b/src/main/java/umc/_th/spring/domain/Member.java
@@ -10,7 +10,9 @@ import umc._th.spring.domain.mapping.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 
 @Entity
@@ -45,16 +47,16 @@ public class Member extends BaseEntity {
 
     private Integer point;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-    private List<MemberPrefer> memberPreferList = new ArrayList<>();
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<MemberPrefer> memberPreferList = new HashSet<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviewList = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberMission> memberMissionList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberNotification> memberNotificationList = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)

--- a/src/main/java/umc/_th/spring/domain/Member.java
+++ b/src/main/java/umc/_th/spring/domain/Member.java
@@ -39,12 +39,19 @@ public class Member extends BaseEntity {
     private SocialType socialType;
 
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10) DEFAULT 'ACTIVE'")
     private MemberStatus status;
 
     private LocalDate inactiveDate;
 
     private String email;
 
+    private String phone;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean isPhoneAuthorized;
+
+    @Column(columnDefinition = "INTEGER DEFAULT 0")
     private Integer point;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -61,4 +68,21 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberNotificationType> memberNotificationTypeList = new ArrayList<>();
+
+    @Override
+    public String toString() {
+        return "Member" +
+                "id " + id
+                + ", name" + name
+                + ", address" + address
+                + ", specAddress " + specAddress
+                + ", gender " + gender
+                + ", socialType " + socialType
+                + ", status " + status
+                + ", inactiveDate " + inactiveDate
+                + ", email " + email
+                + ", phone " + phone
+                + ", isPhoneAuthorized " + isPhoneAuthorized
+                + ", point " + point;
+    }
 }

--- a/src/main/java/umc/_th/spring/domain/Mission.java
+++ b/src/main/java/umc/_th/spring/domain/Mission.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import umc._th.spring.domain.common.BaseEntity;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -21,7 +23,17 @@ public class Mission extends BaseEntity {
     @Column(nullable = false)
     private Integer reward;
 
+    private LocalDateTime expiredAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store;
+
+    @Override
+    public String toString() {
+        return "mission : "
+                + "point " + point
+                + ", reward " + reward
+                + ", expired at " + expiredAt;
+    }
 }

--- a/src/main/java/umc/_th/spring/domain/Mission.java
+++ b/src/main/java/umc/_th/spring/domain/Mission.java
@@ -1,0 +1,27 @@
+package umc._th.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Mission extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer point;
+
+    @Column(nullable = false)
+    private Integer reward;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+}

--- a/src/main/java/umc/_th/spring/domain/Notification.java
+++ b/src/main/java/umc/_th/spring/domain/Notification.java
@@ -1,0 +1,24 @@
+package umc._th.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.common.BaseEntity;
+import umc._th.spring.domain.enums.NotificationType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @Column(length = 10)
+    private String storeName;
+}

--- a/src/main/java/umc/_th/spring/domain/Region.java
+++ b/src/main/java/umc/_th/spring/domain/Region.java
@@ -1,0 +1,20 @@
+package umc._th.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Region extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String name;
+}

--- a/src/main/java/umc/_th/spring/domain/Review.java
+++ b/src/main/java/umc/_th/spring/domain/Review.java
@@ -1,0 +1,34 @@
+package umc._th.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 40)
+    private String content;
+
+    @Column(nullable = false)
+    private Float rate;
+
+    @Column(length = 50)
+    private String image;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+}

--- a/src/main/java/umc/_th/spring/domain/Store.java
+++ b/src/main/java/umc/_th/spring/domain/Store.java
@@ -1,0 +1,30 @@
+package umc._th.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.common.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Store extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    private Region region;
+
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL)
+    private List<Review> reviewList = new ArrayList<>();
+}

--- a/src/main/java/umc/_th/spring/domain/Store.java
+++ b/src/main/java/umc/_th/spring/domain/Store.java
@@ -21,10 +21,27 @@ public class Store extends BaseEntity {
     @Column(nullable = false, length = 10)
     private String name;
 
+    @Column(nullable = false, length = 50)
+    private String address;
+
+    @Column(columnDefinition = "DOUBLE DEFAULT 0.0 NOT NULL")
+    private Float score;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "region_id")
     private Region region;
 
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL)
     private List<Review> reviewList = new ArrayList<>();
+
+    @Override
+    public String toString() {
+        return "Store{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", address='" + address + '\'' +
+                ", score=" + score +
+                ", region=" + (region != null ? region.getName() : "N/A") +
+                '}';
+    }
 }

--- a/src/main/java/umc/_th/spring/domain/common/BaseEntity.java
+++ b/src/main/java/umc/_th/spring/domain/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package umc._th.spring.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/umc/_th/spring/domain/enums/Gender.java
+++ b/src/main/java/umc/_th/spring/domain/enums/Gender.java
@@ -1,0 +1,5 @@
+package umc._th.spring.domain.enums;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/umc/_th/spring/domain/enums/MemberStatus.java
+++ b/src/main/java/umc/_th/spring/domain/enums/MemberStatus.java
@@ -1,0 +1,5 @@
+package umc._th.spring.domain.enums;
+
+public enum MemberStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/umc/_th/spring/domain/enums/MissionStatus.java
+++ b/src/main/java/umc/_th/spring/domain/enums/MissionStatus.java
@@ -1,5 +1,5 @@
 package umc._th.spring.domain.enums;
 
 public enum MissionStatus {
-    NOT_STARTED, CHALLENGING, COMPLETED
+    CHALLENGING, COMPLETED
 }

--- a/src/main/java/umc/_th/spring/domain/enums/MissionStatus.java
+++ b/src/main/java/umc/_th/spring/domain/enums/MissionStatus.java
@@ -1,0 +1,5 @@
+package umc._th.spring.domain.enums;
+
+public enum MissionStatus {
+    NOT_STARTED, CHALLENGING, COMPLETED
+}

--- a/src/main/java/umc/_th/spring/domain/enums/NotificationType.java
+++ b/src/main/java/umc/_th/spring/domain/enums/NotificationType.java
@@ -1,0 +1,5 @@
+package umc._th.spring.domain.enums;
+
+public enum NotificationType {
+    NEW_EVENT, REVIEW_REPLY, INQUIRY_REPLY
+}

--- a/src/main/java/umc/_th/spring/domain/enums/SocialType.java
+++ b/src/main/java/umc/_th/spring/domain/enums/SocialType.java
@@ -1,0 +1,5 @@
+package umc._th.spring.domain.enums;
+
+public enum SocialType {
+    KAKAO, GOOGLE, NAVER, APPLE
+}

--- a/src/main/java/umc/_th/spring/domain/mapping/MemberMission.java
+++ b/src/main/java/umc/_th/spring/domain/mapping/MemberMission.java
@@ -4,6 +4,7 @@ package umc._th.spring.domain.mapping;
 import jakarta.persistence.*;
 import lombok.*;
 import umc._th.spring.domain.Member;
+import umc._th.spring.domain.Mission;
 import umc._th.spring.domain.common.BaseEntity;
 import umc._th.spring.domain.enums.MissionStatus;
 
@@ -24,4 +25,8 @@ public class MemberMission extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id")
+    private Mission mission;
 }

--- a/src/main/java/umc/_th/spring/domain/mapping/MemberMission.java
+++ b/src/main/java/umc/_th/spring/domain/mapping/MemberMission.java
@@ -1,0 +1,27 @@
+package umc._th.spring.domain.mapping;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.Member;
+import umc._th.spring.domain.common.BaseEntity;
+import umc._th.spring.domain.enums.MissionStatus;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberMission extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private MissionStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/umc/_th/spring/domain/mapping/MemberNotification.java
+++ b/src/main/java/umc/_th/spring/domain/mapping/MemberNotification.java
@@ -1,0 +1,30 @@
+package umc._th.spring.domain.mapping;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.Member;
+import umc._th.spring.domain.Notification;
+import umc._th.spring.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberNotification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT 0")
+    private Boolean isConfirmed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notification_id")
+    private Notification notification;
+}

--- a/src/main/java/umc/_th/spring/domain/mapping/MemberNotificationType.java
+++ b/src/main/java/umc/_th/spring/domain/mapping/MemberNotificationType.java
@@ -1,0 +1,27 @@
+package umc._th.spring.domain.mapping;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.Member;
+import umc._th.spring.domain.common.BaseEntity;
+import umc._th.spring.domain.enums.NotificationType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberNotificationType extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+}

--- a/src/main/java/umc/_th/spring/domain/mapping/MemberPrefer.java
+++ b/src/main/java/umc/_th/spring/domain/mapping/MemberPrefer.java
@@ -1,0 +1,27 @@
+package umc._th.spring.domain.mapping;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc._th.spring.domain.FoodType;
+import umc._th.spring.domain.Member;
+import umc._th.spring.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberPrefer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_type_id")
+    private FoodType foodType;
+}

--- a/src/main/java/umc/_th/spring/repository/MemberRepository/MemberRepository.java
+++ b/src/main/java/umc/_th/spring/repository/MemberRepository/MemberRepository.java
@@ -1,0 +1,7 @@
+package umc._th.spring.repository.MemberRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc._th.spring.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
+}

--- a/src/main/java/umc/_th/spring/repository/MemberRepository/MemberRepositoryCustom.java
+++ b/src/main/java/umc/_th/spring/repository/MemberRepository/MemberRepositoryCustom.java
@@ -1,0 +1,5 @@
+package umc._th.spring.repository.MemberRepository;
+
+
+public interface MemberRepositoryCustom {
+}

--- a/src/main/java/umc/_th/spring/repository/MemberRepository/MemberRepositoryImpl.java
+++ b/src/main/java/umc/_th/spring/repository/MemberRepository/MemberRepositoryImpl.java
@@ -1,0 +1,4 @@
+package umc._th.spring.repository.MemberRepository;
+
+public class MemberRepositoryImpl {
+}

--- a/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepository.java
+++ b/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepository.java
@@ -1,0 +1,7 @@
+package umc._th.spring.repository.MissionRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc._th.spring.domain.Mission;
+
+public interface MissionRepository extends JpaRepository<Mission, Long>, MissionRepositoryCustom {
+}

--- a/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryCustom.java
+++ b/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryCustom.java
@@ -1,5 +1,7 @@
 package umc._th.spring.repository.MissionRepository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import umc._th.spring.domain.Mission;
 import umc._th.spring.domain.enums.MissionStatus;
 
@@ -7,4 +9,5 @@ import java.util.List;
 
 public interface MissionRepositoryCustom {
     List<Mission> findByMemberIdAndStatus(Long memberId, MissionStatus status);
+    Page<Mission> findAllByRegion(Long memberId, Long regionId, Pageable pageable);
 }

--- a/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryCustom.java
+++ b/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryCustom.java
@@ -5,9 +5,7 @@ import org.springframework.data.domain.Pageable;
 import umc._th.spring.domain.Mission;
 import umc._th.spring.domain.enums.MissionStatus;
 
-import java.util.List;
-
 public interface MissionRepositoryCustom {
-    List<Mission> findAllByMemberIdAndStatus(Long memberId, MissionStatus status);
+    Page<Mission> findAllByMemberIdAndStatus(Long memberId, MissionStatus status, Pageable pageable);
     Page<Mission> findAllByRegion(Long memberId, Long regionId, Pageable pageable);
 }

--- a/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryCustom.java
+++ b/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryCustom.java
@@ -1,0 +1,10 @@
+package umc._th.spring.repository.MissionRepository;
+
+import umc._th.spring.domain.Mission;
+import umc._th.spring.domain.enums.MissionStatus;
+
+import java.util.List;
+
+public interface MissionRepositoryCustom {
+    List<Mission> findByMemberIdAndStatus(Long memberId, MissionStatus status);
+}

--- a/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryCustom.java
+++ b/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryCustom.java
@@ -8,6 +8,6 @@ import umc._th.spring.domain.enums.MissionStatus;
 import java.util.List;
 
 public interface MissionRepositoryCustom {
-    List<Mission> findByMemberIdAndStatus(Long memberId, MissionStatus status);
+    List<Mission> findAllByMemberIdAndStatus(Long memberId, MissionStatus status);
     Page<Mission> findAllByRegion(Long memberId, Long regionId, Pageable pageable);
 }

--- a/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
+++ b/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
@@ -1,0 +1,34 @@
+package umc._th.spring.repository.MissionRepository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import umc._th.spring.domain.Mission;
+import umc._th.spring.domain.QMission;
+import umc._th.spring.domain.enums.MissionStatus;
+import umc._th.spring.domain.mapping.QMemberMission;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MissionRepositoryImpl implements MissionRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+    private final QMission mission = QMission.mission;
+    private final QMemberMission memberMission = QMemberMission.memberMission;
+
+    @Override
+    public List<Mission> findByMemberIdAndStatus(@NonNull Long memberId, @NonNull MissionStatus status) {
+        BooleanBuilder predicate = new BooleanBuilder()
+                .and(memberMission.member.id.eq(memberId))
+                .and(memberMission.status.eq(status));
+
+        return queryFactory.selectFrom(mission)
+                .join(memberMission).on(mission.id.eq(memberMission.mission.id))
+                .where(predicate)
+                .fetch();
+    }
+}

--- a/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
+++ b/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
@@ -29,7 +29,7 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom{
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Mission> findByMemberIdAndStatus(@NonNull Long memberId, @NonNull MissionStatus status) {
+    public List<Mission> findAllByMemberIdAndStatus(@NonNull Long memberId, @NonNull MissionStatus status) {
         BooleanBuilder predicate = new BooleanBuilder()
                 .and(memberMission.member.id.eq(memberId))
                 .and(memberMission.status.eq(status));

--- a/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
+++ b/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
@@ -1,15 +1,21 @@
 package umc._th.spring.repository.MissionRepository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import umc._th.spring.domain.Mission;
 import umc._th.spring.domain.QMission;
+import umc._th.spring.domain.QStore;
 import umc._th.spring.domain.enums.MissionStatus;
 import umc._th.spring.domain.mapping.QMemberMission;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -19,6 +25,8 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom{
     private final JPAQueryFactory queryFactory;
     private final QMission mission = QMission.mission;
     private final QMemberMission memberMission = QMemberMission.memberMission;
+    private final QStore store = QStore.store;
+    private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public List<Mission> findByMemberIdAndStatus(@NonNull Long memberId, @NonNull MissionStatus status) {
@@ -30,5 +38,37 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom{
                 .join(memberMission).on(mission.id.eq(memberMission.mission.id))
                 .where(predicate)
                 .fetch();
+    }
+
+    @Override
+    public Page<Mission> findAllByRegion(Long memberId, Long regionId, Pageable pageable) {
+        BooleanBuilder predicate = new BooleanBuilder()
+                .and(mission.store.region.id.eq(regionId))
+                .and(mission.expiredAt.gt(LocalDateTime.now()));
+
+        if(memberId != null) {
+            predicate.and(mission.id.notIn(
+                    JPAExpressions
+                            .select(memberMission.mission.id)
+                            .from(memberMission)
+                            .where(memberMission.member.id.eq(memberId)
+                            .and(memberMission.status.eq(MissionStatus.CHALLENGING)))
+            ));
+        }
+
+        List<Mission> missionList = jpaQueryFactory.selectFrom(mission)
+                .leftJoin(mission.store, store).fetchJoin() // fetch join을 사용하여 store 데이터를 한 번에 로딩
+                .where(predicate)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = jpaQueryFactory // count()를 사용하여 효율적으로 카운트를 처리
+                .select(mission.count())
+                .from(mission)
+                .where(predicate)
+                .fetchOne();
+
+        return new PageImpl<>(missionList, pageable, total);
     }
 }

--- a/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
+++ b/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
@@ -29,15 +29,23 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom{
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Mission> findAllByMemberIdAndStatus(@NonNull Long memberId, @NonNull MissionStatus status) {
+    public Page<Mission> findAllByMemberIdAndStatus(@NonNull Long memberId, @NonNull MissionStatus status, Pageable pageable) {
         BooleanBuilder predicate = new BooleanBuilder()
                 .and(memberMission.member.id.eq(memberId))
                 .and(memberMission.status.eq(status));
 
-        return queryFactory.selectFrom(mission)
+        List<Mission> missionList = queryFactory.selectFrom(mission)
                 .join(memberMission).on(mission.id.eq(memberMission.mission.id))
                 .where(predicate)
                 .fetch();
+
+        long total = jpaQueryFactory
+                .select(mission.count())
+                .from(mission)
+                .where(predicate)
+                .fetchOne();
+
+        return new PageImpl<>(missionList, pageable, total);
     }
 
     @Override

--- a/src/main/java/umc/_th/spring/repository/ReviewRepository/ReviewRepository.java
+++ b/src/main/java/umc/_th/spring/repository/ReviewRepository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package umc._th.spring.repository.ReviewRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc._th.spring.domain.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
+}

--- a/src/main/java/umc/_th/spring/repository/ReviewRepository/ReviewRepositoryCustom.java
+++ b/src/main/java/umc/_th/spring/repository/ReviewRepository/ReviewRepositoryCustom.java
@@ -1,0 +1,7 @@
+package umc._th.spring.repository.ReviewRepository;
+
+import umc._th.spring.domain.Review;
+
+public interface ReviewRepositoryCustom {
+    Review addReview(Long memberId, Long storeId, String content, Float rate);
+}

--- a/src/main/java/umc/_th/spring/repository/ReviewRepository/ReviewRepositoryImpl.java
+++ b/src/main/java/umc/_th/spring/repository/ReviewRepository/ReviewRepositoryImpl.java
@@ -1,0 +1,34 @@
+package umc._th.spring.repository.ReviewRepository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import umc._th.spring.domain.Member;
+import umc._th.spring.domain.Review;
+import umc._th.spring.domain.Store;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public Review addReview(Long memberId, Long storeId, String content, Float rate) {
+        // 영속성 컨텍스트로 객체 관계를 처리하기 위해 entity Manager 사용
+            // 엔티티를 메모리에 로드하기 때문에 대량 데이터 처리 시에는 비효율적일 수 있음
+        Member member = entityManager.getReference(Member.class, memberId);
+        Store store = entityManager.getReference(Store.class, storeId);
+            // getReference를 사용하여 실제 데이터베이스 조회를 피하고, 프록시를 사용하도록 유도
+
+        Review review = Review.builder() // 빌더 패턴을 사용하여 객체 생성
+                .member(member)
+                .store(store)
+                .content(content)
+                .rate(rate)
+                .build();
+
+        entityManager.persist(review); // 영속화
+        return review;
+    }
+}

--- a/src/main/java/umc/_th/spring/repository/StoreRepository/StoreRepository.java
+++ b/src/main/java/umc/_th/spring/repository/StoreRepository/StoreRepository.java
@@ -1,0 +1,7 @@
+package umc._th.spring.repository.StoreRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc._th.spring.domain.Store;
+
+public interface StoreRepository extends JpaRepository<Store, Long>, StoreRepositoryCustom {
+}

--- a/src/main/java/umc/_th/spring/repository/StoreRepository/StoreRepositoryCustom.java
+++ b/src/main/java/umc/_th/spring/repository/StoreRepository/StoreRepositoryCustom.java
@@ -1,0 +1,9 @@
+package umc._th.spring.repository.StoreRepository;
+
+import umc._th.spring.domain.Store;
+import java.util.List;
+
+
+public interface StoreRepositoryCustom {
+    List<Store> dynamicQueryWithBooleanBuilder(String name, Float score);
+}

--- a/src/main/java/umc/_th/spring/repository/StoreRepository/StoreRepositoryImpl.java
+++ b/src/main/java/umc/_th/spring/repository/StoreRepository/StoreRepositoryImpl.java
@@ -1,0 +1,35 @@
+package umc._th.spring.repository.StoreRepository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import umc._th.spring.domain.QStore;
+import umc._th.spring.domain.Store;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreRepositoryImpl implements StoreRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+    private final QStore store = QStore.store;
+
+    @Override
+    public List<Store> dynamicQueryWithBooleanBuilder(String name, Float score) {
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        if(name != null) {
+            predicate.and(store.name.eq(name));
+        }
+
+        if(score != null) {
+            predicate.and(store.score.goe(score));
+        }
+
+        return queryFactory.selectFrom(store)
+                .where(predicate)
+                .fetch();
+    }
+}

--- a/src/main/java/umc/_th/spring/service/MemberService/MemberQueryService.java
+++ b/src/main/java/umc/_th/spring/service/MemberService/MemberQueryService.java
@@ -1,0 +1,10 @@
+package umc._th.spring.service.MemberService;
+
+import umc._th.spring.domain.Member;
+
+import java.util.Optional;
+
+public interface MemberQueryService {
+
+    Optional<Member> findById(long id);
+}

--- a/src/main/java/umc/_th/spring/service/MemberService/MemberQueryServiceImpl.java
+++ b/src/main/java/umc/_th/spring/service/MemberService/MemberQueryServiceImpl.java
@@ -1,0 +1,22 @@
+package umc._th.spring.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc._th.spring.domain.Member;
+import umc._th.spring.repository.MemberRepository.MemberRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberQueryServiceImpl implements MemberQueryService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Optional<Member> findById(long id) {
+        return memberRepository.findById(id);
+    }
+}

--- a/src/main/java/umc/_th/spring/service/MissionService/MissionQueryService.java
+++ b/src/main/java/umc/_th/spring/service/MissionService/MissionQueryService.java
@@ -1,5 +1,7 @@
 package umc._th.spring.service.MissionService;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import umc._th.spring.domain.Mission;
 import umc._th.spring.domain.enums.MissionStatus;
 
@@ -7,4 +9,5 @@ import java.util.List;
 
 public interface MissionQueryService {
     List<Mission> findMissionByMemberIdAndStatus(Long memberId, MissionStatus status);
+    Page<Mission> findAllMissionsByRegion(Long memberId, Long regionId, Pageable pageable);
 }

--- a/src/main/java/umc/_th/spring/service/MissionService/MissionQueryService.java
+++ b/src/main/java/umc/_th/spring/service/MissionService/MissionQueryService.java
@@ -1,0 +1,10 @@
+package umc._th.spring.service.MissionService;
+
+import umc._th.spring.domain.Mission;
+import umc._th.spring.domain.enums.MissionStatus;
+
+import java.util.List;
+
+public interface MissionQueryService {
+    List<Mission> findMissionByMemberIdAndStatus(Long memberId, MissionStatus status);
+}

--- a/src/main/java/umc/_th/spring/service/MissionService/MissionQueryService.java
+++ b/src/main/java/umc/_th/spring/service/MissionService/MissionQueryService.java
@@ -5,9 +5,7 @@ import org.springframework.data.domain.Pageable;
 import umc._th.spring.domain.Mission;
 import umc._th.spring.domain.enums.MissionStatus;
 
-import java.util.List;
-
 public interface MissionQueryService {
-    List<Mission> findAllMissionsByMemberIdAndStatus(Long memberId, MissionStatus status);
+    Page<Mission> findAllMissionsByMemberIdAndStatus(Long memberId, MissionStatus status, Pageable pageable);
     Page<Mission> findAllMissionsByRegion(Long memberId, Long regionId, Pageable pageable);
 }

--- a/src/main/java/umc/_th/spring/service/MissionService/MissionQueryService.java
+++ b/src/main/java/umc/_th/spring/service/MissionService/MissionQueryService.java
@@ -8,6 +8,6 @@ import umc._th.spring.domain.enums.MissionStatus;
 import java.util.List;
 
 public interface MissionQueryService {
-    List<Mission> findMissionByMemberIdAndStatus(Long memberId, MissionStatus status);
+    List<Mission> findAllMissionsByMemberIdAndStatus(Long memberId, MissionStatus status);
     Page<Mission> findAllMissionsByRegion(Long memberId, Long regionId, Pageable pageable);
 }

--- a/src/main/java/umc/_th/spring/service/MissionService/MissionQueryServiceImpl.java
+++ b/src/main/java/umc/_th/spring/service/MissionService/MissionQueryServiceImpl.java
@@ -19,8 +19,8 @@ public class MissionQueryServiceImpl implements MissionQueryService {
     private final MissionRepository missionRepository;
 
     @Override
-    public List<Mission> findMissionByMemberIdAndStatus(Long memberId, MissionStatus status) {
-        return missionRepository.findByMemberIdAndStatus(memberId, status);
+    public List<Mission> findAllMissionsByMemberIdAndStatus(Long memberId, MissionStatus status) {
+        return missionRepository.findAllByMemberIdAndStatus(memberId, status);
     }
 
     @Override

--- a/src/main/java/umc/_th/spring/service/MissionService/MissionQueryServiceImpl.java
+++ b/src/main/java/umc/_th/spring/service/MissionService/MissionQueryServiceImpl.java
@@ -1,6 +1,8 @@
 package umc._th.spring.service.MissionService;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc._th.spring.domain.Mission;
@@ -12,12 +14,17 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class MissionQueryServiceImpl implements  MissionQueryService {
+public class MissionQueryServiceImpl implements MissionQueryService {
 
     private final MissionRepository missionRepository;
 
     @Override
     public List<Mission> findMissionByMemberIdAndStatus(Long memberId, MissionStatus status) {
         return missionRepository.findByMemberIdAndStatus(memberId, status);
+    }
+
+    @Override
+    public Page<Mission> findAllMissionsByRegion(Long memberId, Long regionId, Pageable pageable) {
+        return missionRepository.findAllByRegion(memberId, regionId, pageable);
     }
 }

--- a/src/main/java/umc/_th/spring/service/MissionService/MissionQueryServiceImpl.java
+++ b/src/main/java/umc/_th/spring/service/MissionService/MissionQueryServiceImpl.java
@@ -9,8 +9,6 @@ import umc._th.spring.domain.Mission;
 import umc._th.spring.domain.enums.MissionStatus;
 import umc._th.spring.repository.MissionRepository.MissionRepository;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -19,8 +17,8 @@ public class MissionQueryServiceImpl implements MissionQueryService {
     private final MissionRepository missionRepository;
 
     @Override
-    public List<Mission> findAllMissionsByMemberIdAndStatus(Long memberId, MissionStatus status) {
-        return missionRepository.findAllByMemberIdAndStatus(memberId, status);
+    public Page<Mission> findAllMissionsByMemberIdAndStatus(Long memberId, MissionStatus status, Pageable pageable) {
+        return missionRepository.findAllByMemberIdAndStatus(memberId, status, pageable);
     }
 
     @Override

--- a/src/main/java/umc/_th/spring/service/MissionService/MissionQueryServiceImpl.java
+++ b/src/main/java/umc/_th/spring/service/MissionService/MissionQueryServiceImpl.java
@@ -1,0 +1,23 @@
+package umc._th.spring.service.MissionService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc._th.spring.domain.Mission;
+import umc._th.spring.domain.enums.MissionStatus;
+import umc._th.spring.repository.MissionRepository.MissionRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MissionQueryServiceImpl implements  MissionQueryService {
+
+    private final MissionRepository missionRepository;
+
+    @Override
+    public List<Mission> findMissionByMemberIdAndStatus(Long memberId, MissionStatus status) {
+        return missionRepository.findByMemberIdAndStatus(memberId, status);
+    }
+}

--- a/src/main/java/umc/_th/spring/service/ReviewService/ReviewCommandService.java
+++ b/src/main/java/umc/_th/spring/service/ReviewService/ReviewCommandService.java
@@ -1,0 +1,8 @@
+package umc._th.spring.service.ReviewService;
+
+
+import umc._th.spring.domain.Review;
+
+public interface ReviewCommandService {
+    Review createReview(Long memberId, Long storeId, String content, Float rate);
+}

--- a/src/main/java/umc/_th/spring/service/ReviewService/ReviewCommandServiceImpl.java
+++ b/src/main/java/umc/_th/spring/service/ReviewService/ReviewCommandServiceImpl.java
@@ -1,0 +1,20 @@
+package umc._th.spring.service.ReviewService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc._th.spring.domain.Review;
+import umc._th.spring.repository.ReviewRepository.ReviewRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewCommandServiceImpl implements ReviewCommandService {
+
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    public Review createReview(Long memberId, Long storeId, String content, Float rate) {
+        return reviewRepository.addReview(memberId, storeId, content, rate);
+    }
+}

--- a/src/main/java/umc/_th/spring/service/StoreService/StoreQueryService.java
+++ b/src/main/java/umc/_th/spring/service/StoreService/StoreQueryService.java
@@ -1,0 +1,12 @@
+package umc._th.spring.service.StoreService;
+
+import umc._th.spring.domain.Store;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StoreQueryService {
+
+    Optional<Store> findStore(Long id);
+    List<Store> findStoreByNameAndScore(String name, Float score);
+}

--- a/src/main/java/umc/_th/spring/service/StoreService/StoreQueryServiceImpl.java
+++ b/src/main/java/umc/_th/spring/service/StoreService/StoreQueryServiceImpl.java
@@ -1,0 +1,33 @@
+package umc._th.spring.service.StoreService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc._th.spring.domain.Store;
+import umc._th.spring.repository.StoreRepository.StoreRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreQueryServiceImpl implements StoreQueryService {
+
+    private final StoreRepository storeRepository;
+
+    @Override
+    public Optional<Store> findStore(Long id) {
+        return storeRepository.findById(id);
+    }
+
+    @Override
+    public List<Store> findStoreByNameAndScore(String name, Float score) {
+        List<Store> filteredStores = storeRepository.dynamicQueryWithBooleanBuilder(name, score);
+
+        filteredStores.forEach(store ->
+                System.out.println("Store : " + store));
+
+        return filteredStores;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
       mode: never
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,16 @@ spring:
     url: jdbc:mysql://localhost:3306/${DB_NAME}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
+  sql:
+    init:
+      mode: never
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+        default_batch_fetch_size: 1000

--- a/src/test/java/umc/_th/spring/ApplicationTests.java
+++ b/src/test/java/umc/_th/spring/ApplicationTests.java
@@ -6,8 +6,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
 }

--- a/src/test/java/umc/_th/spring/ApplicationTests.java
+++ b/src/test/java/umc/_th/spring/ApplicationTests.java
@@ -1,6 +1,5 @@
 package umc._th.spring;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest


### PR DESCRIPTION
- [x] 진행 중, 진행 완료한 미션 조회 쿼리
```
@Override
    public Page<Mission> findAllByMemberIdAndStatus(@NonNull Long memberId, @NonNull MissionStatus status, Pageable pageable) {
        BooleanBuilder predicate = new BooleanBuilder()
                .and(memberMission.member.id.eq(memberId))
                .and(memberMission.status.eq(status));

        List<Mission> missionList = queryFactory.selectFrom(mission)
                .join(memberMission).on(mission.id.eq(memberMission.mission.id))
                .where(predicate)
                .fetch();

        long total = jpaQueryFactory
                .select(mission.count())
                .from(mission)
                .where(predicate)
                .fetchOne();

        return new PageImpl<>(missionList, pageable, total);
```
`@NonNull`을 통해 null이 올 수 없도록 구현
BooleanBuilder를 사용해 조건문 작성, `mission.count()`를 사용하여 전체 카운트를 별도 쿼리로 조회

- [x] 리뷰 작성 쿼리
```
Member member = entityManager.getReference(Member.class, memberId);
Store store = entityManager.getReference(Store.class, storeId);

Review review = Review.builder()
    .member(member)
    .store(store)
    .content(content)
    .rate(rate)
    .build();

entityManager.persist(review);
return review;
```
🚧 QueryDSL로 insert를 시도했으나, QueryDSL의 insert는 JPA 엔티티가 아닌 순수 SQL insert에 매핑되므로 객체 관계를 처리하기에 적합하지 않은 점 (+insert 중 member와 QMember 타입의 객체가 아닌 실제 엔티티 객체가 필요하다는 점)
⇒ 대량 데이터를 처리하지 않을 프로젝트임을 감안하여 Entity Manager를 사용
`getReference` 메서드로 실제 데이터베이스 접근 X → 프록시 객체 조회
builder 패턴을 사용하여 객체 생성, `persist` 메서드로 영속화 진행 → 이후 메소드 종료 될 떄 `@Transactional` 어노테이션 덕분에 알아서 commit 진행
Service단에서 `@Transactional` 추가하여 실행 → 트랜잭션 관리를 명시적으로 추가하여 데이터 일관성 보장

- [x] 홈 화면 쿼리 (현재 선택된 지역에서 도전 가능한 미션 목록 조회)
페이지네이션 등 첫 번째 쿼리와 비슷

- [x] 마이 페이지 쿼리 (내 정보)
findById() 사용, Member를 반환할 수 있도록 구현