### PR TITLE
[WEEK 7] 500 에러가 날 시 디스코드 자동 알림 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.4'
-	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.springframework.boot' version '3.2.5'
+	id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'umc.8th'
@@ -13,34 +13,29 @@ java {
 	}
 }
 
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-}
-
 repositories {
 	mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.2.5'
+	implementation 'org.springframework.boot:spring-boot-starter-web:3.2.5'
+	implementation 'org.springframework.boot:spring-boot-starter-validation:3.2.5'
+
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.2'
 
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
+	compileOnly 'org.projectlombok:lombok:1.18.30'
+	runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
+	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
-	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
-	implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.9'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test:3.2.5'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/src/main/java/umc/_th/spring/Application.java
+++ b/src/main/java/umc/_th/spring/Application.java
@@ -3,6 +3,7 @@ package umc._th.spring;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.PageRequest;
@@ -16,6 +17,7 @@ import umc._th.spring.service.StoreService.StoreQueryService;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/_th/spring/apiPayload/ApiResponse.java
+++ b/src/main/java/umc/_th/spring/apiPayload/ApiResponse.java
@@ -1,0 +1,31 @@
+package umc._th.spring.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import umc._th.spring.apiPayload.code.status.SuccessStatus;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    // 성공
+    public static<T> ApiResponse<T> onSuccess(T result) {
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    // 실패
+    public static<T> ApiResponse<T> onFailure(String code, String message, T data) {
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/umc/_th/spring/apiPayload/code/BaseCode.java
+++ b/src/main/java/umc/_th/spring/apiPayload/code/BaseCode.java
@@ -1,0 +1,8 @@
+package umc._th.spring.apiPayload.code;
+
+public interface BaseCode {
+
+    ReasonDTO getReason();
+
+    ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/umc/_th/spring/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/umc/_th/spring/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package umc._th.spring.apiPayload.code;
+
+public interface BaseErrorCode {
+
+    ErrorReasonDTO getReason();
+
+    ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/umc/_th/spring/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/umc/_th/spring/apiPayload/code/ErrorReasonDTO.java
@@ -1,0 +1,20 @@
+package umc._th.spring.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess() {
+        return isSuccess;
+    }
+}

--- a/src/main/java/umc/_th/spring/apiPayload/code/ReasonDTO.java
+++ b/src/main/java/umc/_th/spring/apiPayload/code/ReasonDTO.java
@@ -1,0 +1,20 @@
+package umc._th.spring.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){
+        return isSuccess;
+    }
+}

--- a/src/main/java/umc/_th/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/_th/spring/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,47 @@
+package umc._th.spring.apiPayload.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import umc._th.spring.apiPayload.code.BaseErrorCode;
+import umc._th.spring.apiPayload.code.ErrorReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트용 에러");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/umc/_th/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/_th/spring/apiPayload/code/status/ErrorStatus.java
@@ -16,10 +16,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수입니다."),
 
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트용 에러");
-
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/umc/_th/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/umc/_th/spring/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,36 @@
+package umc._th.spring.apiPayload.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import umc._th.spring.apiPayload.code.BaseCode;
+import umc._th.spring.apiPayload.code.ReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+}

--- a/src/main/java/umc/_th/spring/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/umc/_th/spring/apiPayload/exception/ExceptionAdvice.java
@@ -69,7 +69,6 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
 
         if(errorReasonHttpStatus.getHttpStatus() == HttpStatus.INTERNAL_SERVER_ERROR) {
-            System.out.println("ㅇㅇ여기까지는온다");
             discordMessageProvider.sendMessage(errorReasonHttpStatus);
         }
         return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);

--- a/src/main/java/umc/_th/spring/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/umc/_th/spring/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,117 @@
+package umc._th.spring.apiPayload.exception;
+
+import java.util.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import umc._th.spring.apiPayload.ApiResponse;
+import umc._th.spring.apiPayload.code.ErrorReasonDTO;
+import umc._th.spring.apiPayload.code.status.ErrorStatus;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/umc/_th/spring/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/umc/_th/spring/apiPayload/exception/ExceptionAdvice.java
@@ -20,10 +20,18 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import umc._th.spring.apiPayload.ApiResponse;
 import umc._th.spring.apiPayload.code.ErrorReasonDTO;
 import umc._th.spring.apiPayload.code.status.ErrorStatus;
+import umc._th.spring.apiPayload.exception.handler.TempHandler;
+import umc._th.spring.service.external.DiscordMessageProvider;
 
 @Slf4j
 @RestControllerAdvice(annotations = {RestController.class})
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    private final DiscordMessageProvider discordMessageProvider;
+
+    public ExceptionAdvice(DiscordMessageProvider discordMessageProvider) {
+        this.discordMessageProvider = discordMessageProvider;
+    }
 
     @ExceptionHandler
     public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
@@ -60,6 +68,11 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(value = GeneralException.class)
     public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
         ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+
+        if(errorReasonHttpStatus.getHttpStatus() == HttpStatus.INTERNAL_SERVER_ERROR) {
+            System.out.println("ㅇㅇ여기까지는온다");
+            discordMessageProvider.sendMessage(errorReasonHttpStatus);
+        }
         return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
     }
 

--- a/src/main/java/umc/_th/spring/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/umc/_th/spring/apiPayload/exception/ExceptionAdvice.java
@@ -20,7 +20,6 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import umc._th.spring.apiPayload.ApiResponse;
 import umc._th.spring.apiPayload.code.ErrorReasonDTO;
 import umc._th.spring.apiPayload.code.status.ErrorStatus;
-import umc._th.spring.apiPayload.exception.handler.TempHandler;
 import umc._th.spring.service.external.DiscordMessageProvider;
 
 @Slf4j
@@ -80,7 +79,6 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                                                            HttpHeaders headers, HttpServletRequest request) {
 
         ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
-        e.printStackTrace();
 
         WebRequest webRequest = new ServletWebRequest(request);
         return super.handleExceptionInternal(

--- a/src/main/java/umc/_th/spring/apiPayload/exception/GeneralException.java
+++ b/src/main/java/umc/_th/spring/apiPayload/exception/GeneralException.java
@@ -7,10 +7,6 @@ public class GeneralException extends RuntimeException {
 
     private BaseErrorCode code;
 
-    public GeneralException() {
-        super();
-    }
-
     public GeneralException(BaseErrorCode errorCode) {
         super(errorCode.getReason().getMessage());
         this.code = errorCode;

--- a/src/main/java/umc/_th/spring/apiPayload/exception/GeneralException.java
+++ b/src/main/java/umc/_th/spring/apiPayload/exception/GeneralException.java
@@ -1,0 +1,27 @@
+package umc._th.spring.apiPayload.exception;
+
+import umc._th.spring.apiPayload.code.BaseErrorCode;
+import umc._th.spring.apiPayload.code.ErrorReasonDTO;
+
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public GeneralException() {
+        super();
+    }
+
+    public GeneralException(BaseErrorCode errorCode) {
+        super(errorCode.getReason().getMessage());
+        this.code = errorCode;
+    }
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+
+}

--- a/src/main/java/umc/_th/spring/apiPayload/exception/handler/TempHandler.java
+++ b/src/main/java/umc/_th/spring/apiPayload/exception/handler/TempHandler.java
@@ -1,0 +1,11 @@
+package umc._th.spring.apiPayload.exception.handler;
+
+import umc._th.spring.apiPayload.code.BaseErrorCode;
+import umc._th.spring.apiPayload.exception.GeneralException;
+
+public class TempHandler extends GeneralException {
+
+    public TempHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/_th/spring/converter/TempConverter.java
+++ b/src/main/java/umc/_th/spring/converter/TempConverter.java
@@ -1,0 +1,18 @@
+package umc._th.spring.converter;
+
+import umc._th.spring.web.dto.TempResponse;
+
+public class TempConverter {
+
+    public static TempResponse.TempTestDTO toTempTestDTO(){
+        return TempResponse.TempTestDTO.builder()
+                .testString("This is Test!")
+                .build();
+    }
+
+    public static TempResponse.TempExceptionDTO toTempExceptionDTO(Integer flag){
+        return TempResponse.TempExceptionDTO.builder()
+                .flag(flag)
+                .build();
+    }
+}

--- a/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
+++ b/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
@@ -22,11 +22,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MissionRepositoryImpl implements MissionRepositoryCustom{
 
-    private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory jpaQueryFactory;
     private final QMission mission = QMission.mission;
     private final QMemberMission memberMission = QMemberMission.memberMission;
     private final QStore store = QStore.store;
-    private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public Page<Mission> findAllByMemberIdAndStatus(@NonNull Long memberId, @NonNull MissionStatus status, Pageable pageable) {
@@ -34,7 +33,7 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom{
                 .and(memberMission.member.id.eq(memberId))
                 .and(memberMission.status.eq(status));
 
-        List<Mission> missionList = queryFactory.selectFrom(mission)
+        List<Mission> missionList = jpaQueryFactory.selectFrom(mission)
                 .join(memberMission).on(mission.id.eq(memberMission.mission.id))
                 .where(predicate)
                 .fetch();

--- a/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
+++ b/src/main/java/umc/_th/spring/repository/MissionRepository/MissionRepositoryImpl.java
@@ -42,6 +42,7 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom{
         long total = jpaQueryFactory
                 .select(mission.count())
                 .from(mission)
+                .join(memberMission).on(mission.id.eq(memberMission.mission.id))
                 .where(predicate)
                 .fetchOne();
 

--- a/src/main/java/umc/_th/spring/service/TempService/TempQueryService.java
+++ b/src/main/java/umc/_th/spring/service/TempService/TempQueryService.java
@@ -1,0 +1,6 @@
+package umc._th.spring.service.TempService;
+
+public interface TempQueryService {
+
+    void CheckFlag(Integer flag);
+}

--- a/src/main/java/umc/_th/spring/service/TempService/TempQueryServiceImpl.java
+++ b/src/main/java/umc/_th/spring/service/TempService/TempQueryServiceImpl.java
@@ -13,5 +13,7 @@ public class TempQueryServiceImpl implements TempQueryService{
     public void CheckFlag(Integer flag) {
         if (flag == 1)
             throw new TempHandler(ErrorStatus.TEMP_EXCEPTION);
+        if (flag == 500)
+            throw new TempHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/umc/_th/spring/service/TempService/TempQueryServiceImpl.java
+++ b/src/main/java/umc/_th/spring/service/TempService/TempQueryServiceImpl.java
@@ -1,0 +1,17 @@
+package umc._th.spring.service.TempService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc._th.spring.apiPayload.code.status.ErrorStatus;
+import umc._th.spring.apiPayload.exception.handler.TempHandler;
+
+@Service
+@RequiredArgsConstructor
+public class TempQueryServiceImpl implements TempQueryService{
+
+    @Override
+    public void CheckFlag(Integer flag) {
+        if (flag == 1)
+            throw new TempHandler(ErrorStatus.TEMP_EXCEPTION);
+    }
+}

--- a/src/main/java/umc/_th/spring/service/external/DiscordMessageProvider.java
+++ b/src/main/java/umc/_th/spring/service/external/DiscordMessageProvider.java
@@ -1,0 +1,27 @@
+package umc._th.spring.service.external;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc._th.spring.apiPayload.code.ErrorReasonDTO;
+import umc._th.spring.web.client.DiscordFeignClient;
+import umc._th.spring.web.dto.DiscordMessage;
+
+@RequiredArgsConstructor
+@Component
+public class DiscordMessageProvider {
+    private final DiscordFeignClient discordFeignClient;
+
+    public void sendMessage(ErrorReasonDTO errorReason) {
+        DiscordMessage discordMessage = DiscordMessage.createDiscordMessage(errorReason);
+        sendMessageToDiscord(discordMessage);
+    }
+
+    private void sendMessageToDiscord(DiscordMessage discordMessage) {
+        try {
+            discordFeignClient.sendMessage(discordMessage);
+        } catch (FeignException e) {
+            throw new IllegalStateException("디스코드 알림 전송에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/umc/_th/spring/web/client/DiscordFeignClient.java
+++ b/src/main/java/umc/_th/spring/web/client/DiscordFeignClient.java
@@ -1,0 +1,12 @@
+package umc._th.spring.web.client;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import umc._th.spring.web.dto.DiscordMessage;
+
+@org.springframework.cloud.openfeign.FeignClient(name = "${discord.name}", url = "${discord.webhook-url}")
+public interface DiscordFeignClient {
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    void sendMessage(@RequestBody DiscordMessage message);
+}

--- a/src/main/java/umc/_th/spring/web/controller/TempController.java
+++ b/src/main/java/umc/_th/spring/web/controller/TempController.java
@@ -6,8 +6,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc._th.spring.apiPayload.ApiResponse;
-import umc._th.spring.apiPayload.code.status.ErrorStatus;
-import umc._th.spring.apiPayload.exception.GeneralException;
 import umc._th.spring.converter.TempConverter;
 import umc._th.spring.service.TempService.TempQueryService;
 import umc._th.spring.web.dto.TempResponse;

--- a/src/main/java/umc/_th/spring/web/controller/TempController.java
+++ b/src/main/java/umc/_th/spring/web/controller/TempController.java
@@ -1,0 +1,31 @@
+package umc._th.spring.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc._th.spring.apiPayload.ApiResponse;
+import umc._th.spring.converter.TempConverter;
+import umc._th.spring.service.TempService.TempQueryService;
+import umc._th.spring.web.dto.TempResponse;
+
+@RestController
+@RequestMapping("/temp")
+@RequiredArgsConstructor
+public class TempController {
+
+    private final TempQueryService tempQueryService;
+
+    @GetMapping("/test")
+    public ApiResponse<TempResponse.TempTestDTO> testAPI() {
+        return ApiResponse.onSuccess(TempConverter.toTempTestDTO());
+    }
+
+
+    @GetMapping("/exception")
+    public ApiResponse<TempResponse.TempExceptionDTO> exceptionAPI(@RequestParam Integer flag){
+        tempQueryService.CheckFlag(flag);
+        return ApiResponse.onSuccess(TempConverter.toTempExceptionDTO(flag));
+    }
+}

--- a/src/main/java/umc/_th/spring/web/controller/TempController.java
+++ b/src/main/java/umc/_th/spring/web/controller/TempController.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc._th.spring.apiPayload.ApiResponse;
+import umc._th.spring.apiPayload.code.status.ErrorStatus;
+import umc._th.spring.apiPayload.exception.GeneralException;
 import umc._th.spring.converter.TempConverter;
 import umc._th.spring.service.TempService.TempQueryService;
 import umc._th.spring.web.dto.TempResponse;
@@ -21,7 +23,6 @@ public class TempController {
     public ApiResponse<TempResponse.TempTestDTO> testAPI() {
         return ApiResponse.onSuccess(TempConverter.toTempTestDTO());
     }
-
 
     @GetMapping("/exception")
     public ApiResponse<TempResponse.TempExceptionDTO> exceptionAPI(@RequestParam Integer flag){

--- a/src/main/java/umc/_th/spring/web/dto/DiscordMessage.java
+++ b/src/main/java/umc/_th/spring/web/dto/DiscordMessage.java
@@ -1,0 +1,14 @@
+package umc._th.spring.web.dto;
+
+import umc._th.spring.apiPayload.code.ErrorReasonDTO;
+
+public record DiscordMessage(String content) {
+
+    public static DiscordMessage createDiscordMessage(ErrorReasonDTO error) {
+        return new DiscordMessage(String.format(
+                "[%s] %s",
+                error.getCode(),
+                error.getMessage()
+        ));
+    }
+}

--- a/src/main/java/umc/_th/spring/web/dto/TempRequest.java
+++ b/src/main/java/umc/_th/spring/web/dto/TempRequest.java
@@ -1,0 +1,4 @@
+package umc._th.spring.web.dto;
+
+public class TempRequest {
+}

--- a/src/main/java/umc/_th/spring/web/dto/TempResponse.java
+++ b/src/main/java/umc/_th/spring/web/dto/TempResponse.java
@@ -1,0 +1,25 @@
+package umc._th.spring.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TempResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TempTestDTO{
+        String testString;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TempExceptionDTO{
+        Integer flag;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,6 @@ spring:
         format_sql: true
         use_sql_comments: true
         default_batch_fetch_size: 1000
+discord:
+  name: discord-feign-client
+  webhook-url: ${DISCORD_WEBHOOK_URL}


### PR DESCRIPTION
- [x] 응답 형식 추가
- [x] 예외 핸들러를 통한 500 에러 감지
외부 라이브러리인 `OpenFeign`을 사용하여 디스코드 웹훅을 연동, `ExceptionAdvice`에서 `_INTERNAL_SERVER_ERROR` 발생 시 알아서 디스코드 알림 메세지를 전송하도록 코드 작성
<img width="460" alt="Screenshot 2025-05-11 at 22 29 35" src="https://github.com/user-attachments/assets/2b1f5b00-1e43-410d-a57c-1e32f63a9a05" />

- **DiscordMessage**
record를 사용하여 불변 데이터 클래스를 정의
content 필드에 에러 로그를 작성한 String을 포함하여 반환
- **DiscordFeignClient**
`@PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)` 어노테이션을 통해 JSON 형식으로 Post 요청 전송함 명시
- **DiscordMessageProvider**
위 DiscordFeignClient를 사용하여 전송 진행, FeignException 발생 시 에러 처리

이후 ExceptionAdvice에서 HttpStatus 확인, INTERNAL_SERVER_ERROR인 경우 provider를 불러 message 전송 메소드 실행
- [x] 개발 서버, 로컬 서버 알림 분리